### PR TITLE
Allow carriage returns for para breaks

### DIFF
--- a/lib/HTML/FromText.pm
+++ b/lib/HTML/FromText.pm
@@ -392,7 +392,8 @@ sub paras {
     my ($self) = @_;
 
     my $options = $self->{options};
-    my @paras   = split /\n{2,}/, $self->{html};
+    (my $html = $self->{html}) =~ s/\r//g;
+    my @paras   = split /\n{2,}/, $html;
     my %paras   = map { $_, { text => $paras[$_], html => undef } } 0 .. $#paras;
     $self->{paras} = \%paras;
 


### PR DESCRIPTION
It would be useful if the `paras` option allowed carriage returns as well as new lines. Would you accept the attached patch? I can write some tests as well, if you let me know which test file they should go in.

I did try and get the regex to include carriage returns, but I couldn't work out how to do it without it counting CRLF as 2 line breaks.
